### PR TITLE
Update curl call to get hugo to be less version dependent

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ EOF
 # Install Hugo
 HUGO_VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | jq -r '.tag_name')
 mkdir tmp/ && cd tmp/
-curl -sSL https://github.com/gohugoio/hugo/releases/download/${HUGO_VERSION}/hugo_extended_${HUGO_VERSION: -6}_Linux-64bit.tar.gz | tar -xvzf-
+curl -sSL https://github.com/gohugoio/hugo/releases/download/${HUGO_VERSION}/hugo_extended_${HUGO_VERSION:1}_Linux-64bit.tar.gz | tar -xvzf-
 mv hugo /usr/local/bin/
 cd .. && rm -rf tmp/
 cd ${GITHUB_WORKSPACE}


### PR DESCRIPTION
The newest release of hugo is [v0.100.0](https://github.com/gohugoio/hugo/releases/tag/v0.100.0) so the entrypoint script was only pulling `.100.0` instead of the expected `0.100.0` for the download URL. This PR updates the code to instead get all of the characters after the first character in `HUGO_VERSION`