### PR TITLE
BUGFIX: entrypoint.sh and Hugo Version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ EOF
 # Install Hugo
 HUGO_VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | jq -r '.tag_name')
 mkdir tmp/ && cd tmp/
-curl -sSL https://github.com/gohugoio/hugo/releases/download/${HUGO_VERSION}/hugo_extended_${HUGO_VERSION: -6}_Linux-64bit.tar.gz | tar -xvzf-
+curl -sSL https://github.com/gohugoio/hugo/releases/download/${HUGO_VERSION}/hugo_extended_${HUGO_VERSION#v}_Linux-64bit.tar.gz | tar -xvzf-
 mv hugo /usr/local/bin/
 cd .. && rm -rf tmp/
 cd ${GITHUB_WORKSPACE}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,13 +49,13 @@ hugo version || exit 1
 
 # Build
 if [ "$MINIFY" = "true" ]; then
-  hugo -e ${HUGO_ENVIRONMENT} --minify
+  hugo -e ${HUGO_ENVIRONMENT} --gc --minify
 else
-  hugo -e ${HUGO_ENVIRONMENT}
+  hugo -e ${HUGO_ENVIRONMENT} --gc 
 fi
 
 # Deploy as configured in your repo
-hugo -e ${HUGO_ENVIRONMENT} deploy
+hugo -e ${HUGO_ENVIRONMENT} deploy --invalidateCDN --maxDeletes -1
 
 # Clear out credentials after we're done
 # We need to re-run `aws configure` with bogus input instead of

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,10 @@ if [ $err -eq 1 ]; then
   exit 1
 fi
 
+if [ -z "$HUGO_ENVIRONMENT" ]; then
+  HUGO_ENVIRONMENT="production"
+fi
+
 # Create a dedicated profile for this action to avoid
 # conflicts with other actions
 aws configure --profile hugo-s3 <<-EOF > /dev/null 2>&1
@@ -45,13 +49,13 @@ hugo version || exit 1
 
 # Build
 if [ "$MINIFY" = "true" ]; then
-  hugo --minify
+  hugo -e ${HUGO_ENVIRONMENT} --minify
 else
-  hugo
+  hugo -e ${HUGO_ENVIRONMENT}
 fi
 
 # Deploy as configured in your repo
-hugo deploy
+hugo -e ${HUGO_ENVIRONMENT} deploy
 
 # Clear out credentials after we're done
 # We need to re-run `aws configure` with bogus input instead of


### PR DESCRIPTION
The original code made the assumption that keeping the rightmost 6 characters would always work. This fails when Hugo's maintainers rolled into v0.100.0, adding another digit. Since the intent is to siphon off the "v", this fix does just that, so the version number digits can be any length and it will not break.