### PR TITLE
Fixes not in gzip format error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ EOF
 # Install Hugo
 HUGO_VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | jq -r '.tag_name')
 mkdir tmp/ && cd tmp/
-curl -sSL https://github.com/gohugoio/hugo/releases/download/${HUGO_VERSION}/hugo_extended_${HUGO_VERSION: -6}_Linux-64bit.tar.gz | tar -xvzf-
+curl -sSL https://github.com/gohugoio/hugo/releases/download/${HUGO_VERSION}/hugo_extended_${HUGO_VERSION: -7}_Linux-64bit.tar.gz | tar -xvzf-
 mv hugo /usr/local/bin/
 cd .. && rm -rf tmp/
 cd ${GITHUB_WORKSPACE}


### PR DESCRIPTION
Right now, hugo versions have three digits on the version number (at the moment `0.102.3`), which leads to an error when running the action, since the `0.` is not included in the download URL:

```sh
➜  blog git:(reverts-epub) ✗ HUGO_VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | jq -r '.tag_name')                         
➜  blog git:(reverts-epub) ✗ echo https://github.com/gohugoio/hugo/releases/download/${HUGO_VERSION}/hugo_extended_${HUGO_VERSION: -6}_Linux-64bit.tar.gz
https://github.com/gohugoio/hugo/releases/download/v0.102.3/hugo_extended_.102.3_Linux-64bit.tar.gz
```

As you can see, the file name is `hugo_extended_.102.3_Linux-64bit.tar.gz`, instead of `hugo_extended_0.102.3_Linux-64bit.tar.gz` at the moment.


That leads to the following error when I run the GitHub Action on my repo:
```sh
Run plopcas/hugo-s3-action@v1.3.0
<line omitted>

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```